### PR TITLE
Escape braces in regex

### DIFF
--- a/Format.pm
+++ b/Format.pm
@@ -72,7 +72,7 @@ my $regex = qr/
                 (-)?          # left-align, rather than right
                 (\d*)?        # (optional) minimum field width
                 (?:\.(\d*))?  # (optional) maximum field width
-                ({.*?})?      # (optional) stuff inside
+                (\{.*?\})?    # (optional) stuff inside
                 (\S)          # actual format character
              )/x;
 sub stringf {


### PR DESCRIPTION
Fix https://rt.cpan.org/Ticket/Display.html?id=124147

Please note that although escaping the right brace is not necessarily required, I escaped it for consistency.

@dlc If you are busy or do not intend to maintain this module anymore, I'm happy to take this over.
Then could you give me write-access to this repository
and give [SKAJI](https://metacpan.org/author/SKAJI) co-maint for String::Format, please?

Thanks. 

